### PR TITLE
Upgrade terraform-aws-private-route53-zone module to v0.13 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terraform-aws-private-route53-zone
 
 
-[![Terraform Version](https://img.shields.io/badge/Terraform%20Version->=0.12.0,<=0.12.31-blue.svg)](https://releases.hashicorp.com/terraform/)
+[![Terraform Version](https://img.shields.io/badge/Terraform%20Version->=0.13.0,<=0.13.7-blue.svg)](https://releases.hashicorp.com/terraform/)
 [![Release](https://img.shields.io/github/release/traveloka/terraform-aws-private-route53-zone.svg)](https://github.com/traveloka/terraform-aws-private-route53-zone/releases)
 [![Last Commit](https://img.shields.io/github/last-commit/traveloka/terraform-aws-private-route53-zone.svg)](https://github.com/traveloka/terraform-aws-private-route53-zone/commits/master)
 [![Issues](https://img.shields.io/github/issues/traveloka/terraform-aws-private-route53-zone.svg)](https://github.com/traveloka/terraform-aws-private-route53-zone/issues)
@@ -40,7 +40,7 @@ Doesn't have any dependencies to any other Terraform module
 
 ## Terraform Versions
 
-This module was created on 04/04/2018 using Terraform version 0.11.14. The latest stable version of Terraform which this module tested working is Terraform 0.12.31 on 20/09/2021
+This module was created on 04/04/2018 using Terraform version 0.11.14. The latest stable version of Terraform which this module tested working is Terraform 0.13.7 on 20/09/2021
 
 ## Terraform Providers
 
@@ -55,7 +55,7 @@ This module was created on 04/04/2018 using Terraform version 0.11.14. The lates
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-private-route53-zone/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Upgrade terraform-aws-private-route53-zone module to v0.13 compatible

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
